### PR TITLE
Add invoice PDF generation from logged hours

### DIFF
--- a/index.html
+++ b/index.html
@@ -135,6 +135,14 @@
         transform: translateY(1px);
       }
 
+      button:disabled {
+        opacity: 0.55;
+        cursor: not-allowed;
+        filter: grayscale(0.15);
+        transform: none;
+        box-shadow: none;
+      }
+
       .secondary-btn {
         background: transparent;
         border: 1px solid rgba(148, 163, 184, 0.4);
@@ -368,6 +376,12 @@
             </div>
           </div>
           <div class="daily-rollup" id="dailyRollup" aria-live="polite"></div>
+          <div class="actions">
+            <button type="button" id="generateInvoice">Generate invoice PDF</button>
+          </div>
+          <p style="margin-top: 8px; color: var(--muted); font-size: 0.85rem">
+            The generated invoice includes placeholder business, client, and routing details.
+          </p>
         </section>
       </div>
 
@@ -406,6 +420,7 @@
       </footer>
     </div>
 
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/jspdf/2.5.1/jspdf.umd.min.js"></script>
     <script>
       const $ = (sel) => document.querySelector(sel);
       const entryForm = $('#entryForm');
@@ -423,6 +438,7 @@
       const entryTotal = $('#entryTotal');
       const clearAllBtn = $('#clearAll');
       const dailyRollup = $('#dailyRollup');
+      const generateInvoiceBtn = $('#generateInvoice');
 
       const STORAGE_KEY = 'time-clock-entries-v1';
       const RATE_KEY = 'time-clock-rate-v1';
@@ -563,6 +579,9 @@
         totalEarnings.textContent = formatCurrency(totalPay);
 
         entryTotal.textContent = sorted.length;
+        if (generateInvoiceBtn) {
+          generateInvoiceBtn.disabled = sorted.length === 0;
+        }
 
         const uniqueDays = byDay.size;
         const avgMs = uniqueDays ? totalMs / uniqueDays : 0;
@@ -645,6 +664,167 @@
         render();
       }
 
+      function generateInvoice() {
+        if (!window.jspdf || !window.jspdf.jsPDF) {
+          alert('Invoice generator is unavailable. Please check your connection and try again.');
+          return;
+        }
+        if (!entries.length) {
+          alert('Add time entries before generating an invoice.');
+          return;
+        }
+
+        const sorted = entries
+          .slice()
+          .sort((a, b) => new Date(a.startISO) - new Date(b.startISO));
+
+        const { jsPDF } = window.jspdf;
+        const doc = new jsPDF({ unit: 'pt', format: 'letter' });
+
+        const margin = 48;
+        const pageWidth = doc.internal.pageSize.getWidth();
+        const pageHeight = doc.internal.pageSize.getHeight();
+        let y = margin;
+
+        const today = new Date();
+        const invoiceNumber = `INV-${today.getFullYear()}${String(today.getMonth() + 1).padStart(2, '0')}${String(
+          today.getDate()
+        ).padStart(2, '0')}-${String(sorted.length).padStart(3, '0')}`;
+
+        doc.setFont('helvetica', 'bold');
+        doc.setFontSize(22);
+        doc.text('Invoice', margin, y);
+        doc.setFontSize(11);
+        doc.setFont('helvetica', 'normal');
+        y += 26;
+        doc.text(`Invoice #: ${invoiceNumber}`, margin, y);
+        y += 16;
+        doc.text(`Invoice Date: ${today.toLocaleDateString()}`, margin, y);
+        y += 24;
+
+        const fromLines = [
+          'Your Name or Business',
+          '123 Placeholder Street',
+          'City, ST 12345',
+          'email@example.com',
+          'Phone: (555) 123-4567',
+        ];
+        const toLines = [
+          'Client Name',
+          'Client Company',
+          '456 Client Avenue',
+          'City, ST 67890',
+          'client@example.com',
+        ];
+
+        doc.setFont('helvetica', 'bold');
+        doc.text('From', margin, y);
+        doc.text('Bill To', margin + 260, y);
+        doc.setFont('helvetica', 'normal');
+        y += 16;
+
+        const maxLines = Math.max(fromLines.length, toLines.length);
+        for (let i = 0; i < maxLines; i += 1) {
+          if (fromLines[i]) {
+            doc.text(fromLines[i], margin, y + i * 14);
+          }
+          if (toLines[i]) {
+            doc.text(toLines[i], margin + 260, y + i * 14);
+          }
+        }
+        y += maxLines * 14 + 20;
+
+        doc.setFont('helvetica', 'bold');
+        doc.text('Payment Details', margin, y);
+        doc.setFont('helvetica', 'normal');
+        y += 16;
+        const paymentLines = [
+          'Bank: Placeholder Bank',
+          'Routing Number: 000000000',
+          'Account Number: 000123456789',
+          'Payment Terms: Due upon receipt',
+        ];
+        paymentLines.forEach((line) => {
+          doc.text(line, margin, y);
+          y += 14;
+        });
+        y += 10;
+
+        const columns = [
+          { label: 'Date', x: margin },
+          { label: 'Hours', x: margin + 120 },
+          { label: 'Rate', x: margin + 200 },
+          { label: 'Amount', x: margin + 280 },
+        ];
+        const notesX = margin + 360;
+        const notesWidth = Math.max(120, pageWidth - margin - notesX);
+
+        function drawTableHeader() {
+          doc.setFont('helvetica', 'bold');
+          doc.text('Date', columns[0].x, y);
+          doc.text('Hours', columns[1].x, y);
+          doc.text('Rate', columns[2].x, y);
+          doc.text('Amount', columns[3].x, y);
+          doc.text('Notes', notesX, y);
+          y += 14;
+          doc.setLineWidth(0.5);
+          doc.line(margin, y, pageWidth - margin, y);
+          y += 10;
+          doc.setFont('helvetica', 'normal');
+        }
+
+        function ensureSpace(heightNeeded) {
+          if (y + heightNeeded > pageHeight - margin) {
+            doc.addPage();
+            y = margin;
+            drawTableHeader();
+          }
+        }
+
+        drawTableHeader();
+
+        let totalHoursDecimal = 0;
+        let totalPay = 0;
+
+        sorted.forEach((entry) => {
+          const start = new Date(entry.startISO);
+          const hoursDecimal = entry.durationMs / 3600000;
+          totalHoursDecimal += hoursDecimal;
+          totalPay += entry.pay;
+
+          const noteLines = entry.note ? doc.splitTextToSize(entry.note, notesWidth) : ['—'];
+          const rowHeight = Math.max(16, noteLines.length * 14);
+
+          ensureSpace(rowHeight + 24);
+
+          doc.text(start.toLocaleDateString(), columns[0].x, y);
+          doc.text(hoursDecimal.toFixed(2), columns[1].x, y);
+          doc.text(`${formatCurrency(entry.rate)}/hr`, columns[2].x, y);
+          doc.text(formatCurrency(entry.pay), columns[3].x, y);
+          noteLines.forEach((line, idx) => {
+            doc.text(line, notesX, y + idx * 14);
+          });
+          y += rowHeight;
+        });
+
+        ensureSpace(60);
+        y += 10;
+        doc.setFont('helvetica', 'bold');
+        doc.text('Summary', margin, y);
+        y += 16;
+        doc.setFont('helvetica', 'normal');
+        doc.text(`Total hours: ${totalHoursDecimal.toFixed(2)}`, margin, y);
+        y += 14;
+        doc.text(`Total amount due: ${formatCurrency(totalPay)}`, margin, y);
+        y += 18;
+        doc.text('Please update the placeholder details before sending to your client.', margin, y);
+        y += 14;
+        doc.text('Thank you for your business!', margin, y);
+
+        const filename = `invoice-${today.toISOString().slice(0, 10)}.pdf`;
+        doc.save(filename);
+      }
+
       entryForm.addEventListener('submit', addEntry);
 
       entryTable.addEventListener('click', (event) => {
@@ -664,6 +844,9 @@
       });
 
       clearAllBtn.addEventListener('click', clearAll);
+      if (generateInvoiceBtn) {
+        generateInvoiceBtn.addEventListener('click', generateInvoice);
+      }
 
       document.addEventListener('DOMContentLoaded', () => {
         setDefaultDate();


### PR DESCRIPTION
## Summary
- add a totals card action to generate a PDF invoice from saved time entries
- integrate jsPDF and build invoice layout with placeholder business, client, and payment details
- disable the invoice button until entries exist and style disabled buttons for clarity

## Testing
- not run (not available)


------
https://chatgpt.com/codex/tasks/task_e_68d727e57ae08325be9405eba21275e3